### PR TITLE
initial windows install support, help/tester wanted

### DIFF
--- a/tools/Install.bat
+++ b/tools/Install.bat
@@ -1,5 +1,7 @@
 del %AppData%\Rime\*.* /Q
 rmdir %AppData%\RIme\opencc /S /Q
-xcopy ..\src\*.* /S %AppData%\Rime\
-rename %AppData%\Rime\default.custom.in %AppData%\Rime\default.custom.yaml
+xcopy ..\src\*.yaml /S %AppData%\Rime\
+xcopy ..\src\*.lua  /S %AppData%\Rime\
+xcopy ..\src\opencc /S %AppData%\Rime\
+xcopy ..\src\default.custom.in %AppData%\Rime\default.custom.yaml
 "C:\Program Files (x86)\Rime\weasel-0.13.0\WeaselDeployer.exe" /deploy

--- a/tools/Install.bat
+++ b/tools/Install.bat
@@ -1,4 +1,5 @@
 del %AppData%\Rime\*.* /Q
 rmdir %AppData%\RIme\opencc /S /Q
-xcopy .\Rime\*.* /S %AppData%\Rime\
+xcopy ..\src\*.* /S %AppData%\Rime\
+rename %AppData%\Rime\default.custom.in %AppData%\Rime\default.custom.yaml
 "C:\Program Files (x86)\Rime\weasel-0.13.0\WeaselDeployer.exe" /deploy


### PR DESCRIPTION
Attempt to correct file path in script. This current implementation will override user's default configuration with `default.custom.in` instead of modify it in place, mainly because Python is not shipped with Windows (and it is not trivial to set up). Also none of the essential tools (awk, sed, etc.) we used to modify scripts in place are available on Windows. Keep in mind that normal users may not want to bother install Cygwin/MSYS or WSL on their machine when they just simply want a working input method getting deployed.